### PR TITLE
[CROW-141] Add owner population when querying campaigns

### DIFF
--- a/src/features/campaigns/repositories/mongo/campaigns.repository.spec.ts
+++ b/src/features/campaigns/repositories/mongo/campaigns.repository.spec.ts
@@ -43,6 +43,7 @@ describe('Campaign Statuses Repository', () => {
             lean: jest.fn(),
             create: jest.fn(),
             save: jest.fn(),
+            populate: jest.fn(),
           },
         },
       ],
@@ -57,6 +58,7 @@ describe('Campaign Statuses Repository', () => {
   describe('findAll method', () => {
     it('should call findAll method with page 0 and size 1', async () => {
       jest.spyOn(campaignModel, 'find').mockReturnValue({
+        populate: jest.fn().mockReturnThis(),
         sort: jest.fn().mockReturnThis(),
         skip: jest.fn().mockReturnThis(),
         limit: jest.fn().mockReturnThis(),
@@ -74,6 +76,7 @@ describe('Campaign Statuses Repository', () => {
 
     it('should call findAll method with page 1 and size 1', async () => {
       jest.spyOn(campaignModel, 'find').mockReturnValue({
+        populate: jest.fn().mockReturnThis(),
         sort: jest.fn().mockReturnThis(),
         skip: jest.fn().mockReturnThis(),
         limit: jest.fn().mockReturnThis(),
@@ -92,7 +95,9 @@ describe('Campaign Statuses Repository', () => {
 
   describe('findOne method', () => {
     it('should call findOne and throw NotFoundException', async () => {
-      jest.spyOn(campaignModel, 'findOne').mockResolvedValue(null);
+      jest.spyOn(campaignModel, 'findOne').mockReturnValue({
+        populate: jest.fn().mockResolvedValue(null),
+      } as any);
 
       await expect(
         campaignsRepository.findOne(campaignId),
@@ -100,9 +105,9 @@ describe('Campaign Statuses Repository', () => {
     });
 
     it('should call findAll and return related campaign', async () => {
-      jest
-        .spyOn(campaignModel, 'findOne')
-        .mockResolvedValue(mongoBuiltCampaign);
+      jest.spyOn(campaignModel, 'findOne').mockReturnValue({
+        populate: jest.fn().mockResolvedValue(mongoBuiltCampaign),
+      } as any);
 
       const response = await campaignsRepository.findOne(campaignId);
 
@@ -201,10 +206,12 @@ describe('Campaign Statuses Repository', () => {
   describe('updateTokenAmount', () => {
     it('Should update campign currentAmount data with increase movement', async () => {
       jest.spyOn(campaignModel, 'save' as any).mockResolvedValue(null);
-      jest.spyOn(campaignModel, 'findOne').mockResolvedValue({
-        ...mongoBuiltCampaign,
-        save: jest.fn(),
-      });
+      jest.spyOn(campaignModel, 'findOne').mockReturnValue({
+        populate: jest.fn().mockResolvedValue({
+          ...mongoBuiltCampaign,
+          save: jest.fn(),
+        }),
+      } as any);
 
       const { onchainId, goal } = mongoBuiltCampaign;
 
@@ -220,10 +227,12 @@ describe('Campaign Statuses Repository', () => {
 
     it('Should update campign currentAmount data with decrease movement', async () => {
       jest.spyOn(campaignModel, 'save' as any).mockResolvedValue(null);
-      jest.spyOn(campaignModel, 'findOne').mockResolvedValue({
-        ...mongoBuiltCampaign,
-        save: jest.fn(),
-      });
+      jest.spyOn(campaignModel, 'findOne').mockReturnValue({
+        populate: jest.fn().mockResolvedValue({
+          ...mongoBuiltCampaign,
+          save: jest.fn(),
+        }),
+      } as any);
 
       const { onchainId, goal } = mongoBuiltCampaign;
 

--- a/src/features/campaigns/repositories/mongo/campaigns.repository.ts
+++ b/src/features/campaigns/repositories/mongo/campaigns.repository.ts
@@ -38,7 +38,6 @@ export class CampaignsMongoRepository {
       ...(ownerId && { owner: ownerId }),
     };
 
-    // TODO: I think we can use aggregate here
     const campaings = await this.campaignModel
       .find(filters)
       .populate('owner')
@@ -51,7 +50,6 @@ export class CampaignsMongoRepository {
   }
 
   async findOne(onchainId: string) {
-    // TODO: I think we can use aggregate here
     const campaing = await this.campaignModel
       .findOne({ onchainId: onchainId })
       .populate('owner');

--- a/src/features/campaigns/repositories/mongo/campaigns.repository.ts
+++ b/src/features/campaigns/repositories/mongo/campaigns.repository.ts
@@ -38,8 +38,10 @@ export class CampaignsMongoRepository {
       ...(ownerId && { owner: ownerId }),
     };
 
+    // TODO: I think we can use aggregate here
     const campaings = await this.campaignModel
       .find(filters)
+      .populate('owner')
       .sort({ created: -1 })
       .skip(skipValue)
       .limit(size)
@@ -49,7 +51,11 @@ export class CampaignsMongoRepository {
   }
 
   async findOne(onchainId: string) {
-    const campaing = await this.campaignModel.findOne({ onchainId: onchainId });
+    // TODO: I think we can use aggregate here
+    const campaing = await this.campaignModel
+      .findOne({ onchainId: onchainId })
+      .populate('owner');
+
     if (!campaing) {
       throw new NotFoundException();
     }


### PR DESCRIPTION
# 📋 Board card

* [Backend - populate owner on GET /campaigns response](https://loopstudio.atlassian.net/browse/CROW-141)

&nbsp;


# ℹ️ Description

Add owner population when querying campaigns (in both GET /campaigns and GET /campaigns/:id endpoints)

&nbsp;


# 🕵️ How was it tested?

- [x] Tested manually
- [x] Unit test passed and coverage threshold fulfilled

&nbsp;


# 🎥 Demo
![Screenshot 2023-02-16 at 17 56 54](https://user-images.githubusercontent.com/17997480/219485024-4d2ea22c-f2a0-4cec-aa6f-1efb01c00d86.png)

![Screenshot 2023-02-16 at 17 57 06](https://user-images.githubusercontent.com/17997480/219485068-a729ff8d-40d7-4c48-afba-738e80306f42.png)
