### PR TITLE
[CROW-166] Add search and total in campaigns pledge

### DIFF
--- a/src/features/campaigns/controllers/campaign-pledge/campaigns-pledge.controller.spec.ts
+++ b/src/features/campaigns/controllers/campaign-pledge/campaigns-pledge.controller.spec.ts
@@ -41,6 +41,7 @@ describe('CampaignsPledge Controller', () => {
       page,
       size,
       userId: user._id,
+      search: '',
     };
 
     await controller.findAllByUser(request, size, page);
@@ -55,6 +56,7 @@ describe('CampaignsPledge Controller', () => {
       page: DEFAULT_PAGE,
       size: DEFAULT_PAGE_SIZE,
       userId: user._id,
+      search: '',
     };
 
     await controller.findAllByUser(request);

--- a/src/features/campaigns/controllers/campaign-pledge/campaigns-pledge.controller.ts
+++ b/src/features/campaigns/controllers/campaign-pledge/campaigns-pledge.controller.ts
@@ -14,6 +14,7 @@ export class CampaignsPledgeController {
     @Request() request: ExpressRequest,
     @Query('size') size: number = DEFAULT_PAGE_SIZE,
     @Query('page') page: number = DEFAULT_PAGE,
+    @Query('search') search = '',
   ): Promise<APIResponse> {
     const {
       user: { _id: userId },
@@ -22,6 +23,7 @@ export class CampaignsPledgeController {
       page,
       size,
       userId,
+      search,
     });
     return { data: campaigns };
   }

--- a/src/features/campaigns/repositories/mongo/campaign-pledge/campaign-pledge.repository.ts
+++ b/src/features/campaigns/repositories/mongo/campaign-pledge/campaign-pledge.repository.ts
@@ -38,13 +38,16 @@ export class CampaignPledgeMongoRepository {
     page,
     size,
     userId,
+    search,
   }: {
     page: number;
     size: number;
     userId: string;
+    search: string;
   }) {
     const skipValue = page > 0 ? (page - 1) * size : 0;
-    const campaings = await this.campaignPledgeModel.aggregate([
+
+    const campaigns = await this.campaignPledgeModel.aggregate([
       {
         $match: { user: userId },
       },
@@ -73,8 +76,16 @@ export class CampaignPledgeMongoRepository {
           as: 'campaigns',
         },
       },
+      {
+        $match: {
+          $or: [
+            { 'campaigns.title': { $regex: search } },
+            { 'campaigns.subtitle': { $regex: search } },
+          ],
+        },
+      },
     ]);
 
-    return campaings;
+    return campaigns;
   }
 }

--- a/src/features/campaigns/services/campaign-pledge/campaign-pledge.service.spec.ts
+++ b/src/features/campaigns/services/campaign-pledge/campaign-pledge.service.spec.ts
@@ -156,17 +156,19 @@ describe('CampaignPledgeService', () => {
           userId: 'user-1',
         },
       ];
+      const total = 2;
       jest
         .spyOn(campaignPledgeMongoRepository, 'findAll')
-        .mockResolvedValue(campaigns);
+        .mockResolvedValue({ campaigns, total });
 
       const result = await campaignPledgeService.findAllByUser({
         page: 1,
         size: 10,
         userId: 'user-1',
+        search: '',
       });
 
-      expect(result).toEqual(campaigns);
+      expect(result).toEqual({ campaigns, total });
     });
   });
 });

--- a/src/features/campaigns/services/campaign-pledge/campaign-pledge.service.ts
+++ b/src/features/campaigns/services/campaign-pledge/campaign-pledge.service.ts
@@ -93,15 +93,18 @@ export class CampaignPledgeService {
     page,
     size,
     userId,
+    search,
   }: {
     page: number;
     size: number;
     userId: string;
+    search: string;
   }) {
     const campaigns = await this.campaignPledgeMongoRepository.findAll({
       page,
       size,
       userId,
+      search,
     });
 
     return campaigns;

--- a/src/features/campaigns/services/campaigns.service.ts
+++ b/src/features/campaigns/services/campaigns.service.ts
@@ -73,7 +73,7 @@ export class CampaignsService {
     page: number;
     size: number;
     ownerId: string | null;
-    search: string | null;
+    search: string;
   }) {
     const campaigns = await this.campaignsMongoRepository.findAll({
       page,


### PR DESCRIPTION
# 📋 Board card

* [Backend: Pledged projects list page - Search](https://loopstudio.atlassian.net/browse/CROW-166)

&nbsp;


# ℹ️ Description

- Add search on get campaigns pledge.
- Add "total" in the response

&nbsp;


# 🕵️ How was it tested?

- [x] Tested manually
- [x] Unit test passed and coverage threshold fulfilled
