### PR TITLE
CROW-221 Handle _id and onchainID on campaings findOne method

### DIFF
--- a/src/common/utils/index.ts
+++ b/src/common/utils/index.ts
@@ -3,3 +3,7 @@ import { randomUUID } from 'crypto';
 export const getNonce = (): string => {
   return randomUUID();
 };
+
+export const isValidObjectId = (id: string) => {
+  return id.match(/^[0-9a-fA-F]{24}$/);
+};

--- a/src/features/campaigns/repositories/mongo/campaigns.repository.spec.ts
+++ b/src/features/campaigns/repositories/mongo/campaigns.repository.spec.ts
@@ -145,7 +145,7 @@ describe('Campaign Statuses Repository', () => {
   describe('update method', () => {
     it('should call update method and fails because campaign does not exist', async () => {
       jest.spyOn(campaignModel, 'findOne').mockReturnValue({
-        exec: jest.fn().mockResolvedValue(null),
+        populate: jest.fn().mockResolvedValue(null),
       } as any);
 
       await expect(
@@ -158,7 +158,7 @@ describe('Campaign Statuses Repository', () => {
 
     it('should call update method and fails because I want to update an unallowed property', async () => {
       jest.spyOn(campaignModel, 'findOne').mockReturnValue({
-        exec: jest.fn().mockResolvedValue(mongoBuiltCampaign),
+        populate: jest.fn().mockResolvedValue(mongoBuiltCampaign),
       } as any);
 
       await expect(
@@ -177,7 +177,7 @@ describe('Campaign Statuses Repository', () => {
       delete modifiedMongoBuiltUpdatedCampaign.save;
 
       jest.spyOn(campaignModel, 'findOne').mockReturnValue({
-        exec: jest.fn().mockResolvedValue(mongoBuiltCampaign),
+        populate: jest.fn().mockResolvedValue(mongoBuiltCampaign),
       } as any);
 
       const response = await campaignsRepository.update({

--- a/src/features/campaigns/repositories/mongo/campaigns.repository.ts
+++ b/src/features/campaigns/repositories/mongo/campaigns.repository.ts
@@ -4,13 +4,13 @@ import {
   NotFoundException,
 } from '@nestjs/common';
 import { InjectModel } from '@nestjs/mongoose';
-import { isValidObjectId, Model } from 'mongoose';
+import { isValidObjectId, Model, ObjectId } from 'mongoose';
 import { BigNumber } from 'ethers';
 import { formatEther, parseEther } from 'ethers/lib/utils';
 
 import { Campaign, CampaignDocument } from '../../schemas/campaign.schema';
 import { campaignFieldsToModify, movementTypeEnum } from '../../constants';
-import { movementType, searchFilters } from '../../types';
+import { movementType, OnchainId, searchFilters } from '../../types';
 import { CreateCampaignDto } from '../../dto/create-campaign.dto';
 import { UpdateCampaignDto } from '../../dto/update-campaign.dto';
 import { CampaignLaunchEventDto } from '../../dto/campaign-launch-event-dto';
@@ -57,7 +57,7 @@ export class CampaignsMongoRepository {
     return { campaigns, total: count };
   }
 
-  async findOne(id: string) {
+  async findOne(id: ObjectId | OnchainId) {
     const isAnObjectId = isValidObjectId(id);
 
     const filters = new Map();
@@ -168,7 +168,7 @@ export class CampaignsMongoRepository {
     id,
     updateCampaignDto,
   }: {
-    id: string;
+    id: ObjectId | OnchainId;
     updateCampaignDto: UpdateCampaignDto;
   }) {
     const existingCampaign = await this.findOne(id);

--- a/src/features/campaigns/services/campaigns.service.spec.ts
+++ b/src/features/campaigns/services/campaigns.service.spec.ts
@@ -134,9 +134,12 @@ describe('UsersService', () => {
 
       const response = await campaignService.findOne(campaignId);
 
-      const campaignResponse = { campaign: mongoBuiltCampaign, pledges: 1 };
+      const campaignResponse = {
+        campaign: { ...mongoBuiltCampaign },
+        pledges: 1,
+      };
 
-      expect(response).toStrictEqual({ campaign: campaignResponse });
+      expect(response).toStrictEqual(campaignResponse);
       expect(campaignsRepository.findOne).toBeCalledWith(campaignId);
     });
   });

--- a/src/features/campaigns/services/campaigns.service.ts
+++ b/src/features/campaigns/services/campaigns.service.ts
@@ -93,9 +93,7 @@ export class CampaignsService {
       campaign,
     );
 
-    const campaignWithTotal = { campaign, pledges };
-
-    return { campaign: campaignWithTotal };
+    return { campaign, pledges };
   }
 
   async findByLaunchEvent(campaignLaunchEventDto: CampaignLaunchEventDto) {

--- a/src/features/campaigns/types/index.ts
+++ b/src/features/campaigns/types/index.ts
@@ -7,3 +7,5 @@ export type searchFilters = {
     { subtitle: { $regex: string; $options: string } },
   ];
 };
+
+export type OnchainId = string;


### PR DESCRIPTION
# 📋 Board card

* [Issue on launch listener](https://loopstudio.atlassian.net/browse/CROW-211)

&nbsp;


# ℹ️ Description

- Issue when finding one campaign was fixed. Now you can send either an _id or a onchainId
- CampaignPledgeService now uses the related abstract class
- Minor change to return { campaign, pledges } instead of { campaign: { campaign }, pledges }

&nbsp;


# 🕵️ How was it tested?

- [x] Tested manually
- [x] Unit test passed and coverage threshold fulfilled

&nbsp;

