### PR TITLE
[CROW-213] Pledges in response

### DIFF
--- a/src/features/campaigns/controllers/campaigns.controller.spec.ts
+++ b/src/features/campaigns/controllers/campaigns.controller.spec.ts
@@ -73,13 +73,15 @@ describe('Campaigns Controller', () => {
 
   describe('findOne method', () => {
     it('should call findOne campaignsService method without errors', async () => {
+      const pledges = 1;
       jest
         .spyOn(campaignsService, 'findOne')
-        .mockResolvedValue({ campaign: mongoBuiltCampaign } as any);
-
+        .mockResolvedValue({ campaign: mongoBuiltCampaign, pledges } as any);
       const response = await campaignsController.findOne(campaignId);
 
-      expect(response).toStrictEqual({ data: mongoBuiltCampaign });
+      expect(response).toStrictEqual({
+        data: { campaign: mongoBuiltCampaign, pledges },
+      });
     });
   });
 

--- a/src/features/campaigns/controllers/campaigns.controller.ts
+++ b/src/features/campaigns/controllers/campaigns.controller.ts
@@ -64,8 +64,8 @@ export class CampaignsController {
   @Public()
   @Get(':id')
   async findOne(@Param('id') id: string): Promise<APIResponse> {
-    const { campaign } = await this.campaignsService.findOne(id);
-    return { data: campaign };
+    const { campaign, pledges } = await this.campaignsService.findOne(id);
+    return { data: { campaign, pledges } };
   }
 
   @Patch(':id')


### PR DESCRIPTION
# 📋 Board card

* [Backend - The campaigns/id GET does not provide data on the total number of pledges made. ](https://loopstudio.atlassian.net/browse/CROW-213)

&nbsp;


# ℹ️ Description

Add pleges in get campaigns/:id

&nbsp;


# 🕵️ How was it tested?

- [x] Tested manually
- [x] Unit test passed and coverage threshold fulfilled

&nbsp;

