### PR TITLE
Fix current amount value when pleding a campaign

### DIFF
--- a/src/features/campaigns/repositories/mongo/campaigns.repository.ts
+++ b/src/features/campaigns/repositories/mongo/campaigns.repository.ts
@@ -212,7 +212,11 @@ export class CampaignsMongoRepository {
 
       campaign.currentAmount[tokenIndex].amount =
         action === movementTypeEnum.INCREASE
-          ? formatEther(currentValue.add(amountToChange))
+          ? formatEther(
+              parseEther(currentValue.toString()).add(
+                parseEther(amountToChange.toString()),
+              ),
+            )
           : formatEther(currentValue.sub(amountToChange));
 
       await campaign.save();


### PR DESCRIPTION
# 📋 Board card

* [Backend - The current amount field is not being updated once a pledge has been made.](https://loopstudio.atlassian.net/browse/CROW-212)

&nbsp;


# ℹ️ Description

This PR fixes amount value when pledge a campaign

&nbsp;


# 🕵️ How was it tested?

- [x] Tested manually
- [ ] Unit test passed and coverage threshold fulfilled

