### PR TITLE
Hotfix campaing creation currentAmount tokenAddress value

### DIFF
--- a/src/features/campaigns/repositories/mongo/campaigns.repository.ts
+++ b/src/features/campaigns/repositories/mongo/campaigns.repository.ts
@@ -140,7 +140,7 @@ export class CampaignsMongoRepository {
     } = createCampaignData;
 
     const currentAmount = goal.map((tokenAmount) => ({
-      token: tokenAmount.tokenAddress,
+      tokenAddress: tokenAmount.tokenAddress,
       amount: 0,
     }));
 


### PR DESCRIPTION
# 📋 Board card

* [No card](https://jira.com)

&nbsp;


# ℹ️ Description

- Hotfix in order to avoid creating campaigns with currentAmount.tokenAddress as an empty field

&nbsp;


# 🕵️ How was it tested?

- [x] Tested manually
- [x] Unit test passed and coverage threshold fulfilled

&nbsp;


# 🎥 Demo
No this time
